### PR TITLE
space_level method lstrip was not supporting \t, corrected it

### DIFF
--- a/shconfparser/parser.py
+++ b/shconfparser/parser.py
@@ -28,7 +28,7 @@ class Parser:
         return logger
 
     def _space_level(self, line):
-        return len(line) - len(line.lstrip(' '))
+        return len(line) - len(line.lstrip())
 
     def _convert_to_dict(self, tree, level=0):
         temp_dict = OrderedDict()


### PR DESCRIPTION
#12 